### PR TITLE
Use DGL's builtin functions instead of UDF and support dgl 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Hyperparameters could be found in ./utils/config.json and you can adjust them wh
 
 Principal environmental dependencies as follows:
 - [PyTorch 1.5.0](https://pytorch.org/)
-- [dgl 0.4.3](https://www.dgl.ai/)
+- [dgl 0.5.2](https://www.dgl.ai/)
 - [tqdm](https://github.com/tqdm/tqdm)
 - [numpy](https://github.com/numpy/numpy)
 - [pandas](https://github.com/pandas-dev/pandas)

--- a/model/aggregate_nodes_temporal_feature.py
+++ b/model/aggregate_nodes_temporal_feature.py
@@ -20,7 +20,7 @@ class aggregate_nodes_temporal_feature(nn.Module):
         :param nodes_output: the output of self-attention model in time dimension, (n_1+n_2+..., T_max, F)
         :return: aggregated_features, (n_1+n_2+..., F)
         """
-        nums_nodes, id = graph.batch_num_nodes, 0
+        nums_nodes, id = graph.batch_num_nodes(), 0
         aggregated_features = []
         for num_nodes, length in zip(nums_nodes, lengths):
             # get each user's length, tensor, shape, (user_nodes, user_length, item_embed_dim)

--- a/model/global_gated_update.py
+++ b/model/global_gated_update.py
@@ -20,7 +20,7 @@ class global_gated_update(nn.Module):
         :param nodes_output: the output of self-attention model in time dimension, (n_1+n_2+..., F)
         :return:
         """
-        nums_nodes, id = graph.batch_num_nodes, 0
+        nums_nodes, id = graph.batch_num_nodes(), 0
         items_embedding = self.item_embedding(torch.tensor([i for i in range(self.items_total)]).to(nodes.device))
         batch_embedding = []
         for num_nodes in nums_nodes:

--- a/train/train_model.py
+++ b/train/train_model.py
@@ -7,7 +7,7 @@ from torch import optim
 from torch.utils.data import DataLoader
 from tensorboardX import SummaryWriter
 
-from utils.util import save_model, convert_to_gpu, convert_all_data_to_gpu
+from utils.util import save_model, convert_to_gpu, convert_graph_to_gpu, convert_all_data_to_gpu
 from utils.metric import get_metric
 
 from tqdm import tqdm
@@ -69,6 +69,7 @@ def train_model(model: nn.Module,
             total_loss = 0.0
             tqdm_loader = tqdm(data_loader_dic[name])
             for step, (g, nodes_feature, edges_weight, lengths, nodes, truth_data, users_frequency) in enumerate(tqdm_loader):
+                g = convert_graph_to_gpu(g) 
                 nodes_feature, edges_weight, lengths, nodes, truth_data, users_frequency = \
                     convert_all_data_to_gpu(nodes_feature, edges_weight, lengths, nodes, truth_data, users_frequency)
 

--- a/utils/data_container.py
+++ b/utils/data_container.py
@@ -59,15 +59,13 @@ class SetDataset(Dataset):
         # print(nodes)
         nodes_feature = self.item_embedding_matrix(convert_to_gpu(nodes))
         # construct graph for the user
-        g = dgl.DGLGraph()
         project_nodes = torch.tensor(list(range(nodes.shape[0])))
         # construct fully connected graph, containing N nodes, unweighted
-        g.add_nodes(project_nodes.shape[0])
         # (0, 0), (0, 1), ..., (0, N-1), (1, 0), (1, 1), ..., (1, N-1), ...
         # src -> [0, 0, 0, ... N-1, N-1, N-1, ...],  dst -> [0, 1, ..., N-1, ..., 0, 1, ..., N-1]
         src = torch.stack([project_nodes for _ in range(project_nodes.shape[0])], dim=1).flatten().tolist()
         dst = torch.stack([project_nodes for _ in range(project_nodes.shape[0])], dim=0).flatten().tolist()
-        g.add_edges(src, dst)
+        g = dgl.graph((src, dst), num_nodes=project_nodes.shape[0])
         edges_weight_dict = self.get_edges_weight(user_data[:-1])
         # add self-loop
         for node in nodes.tolist():

--- a/utils/util.py
+++ b/utils/util.py
@@ -12,6 +12,10 @@ def convert_to_gpu(data):
         data = data.cuda(get_attribute('cuda'))
     return data
 
+def convert_graph_to_gpu(g):
+    if get_attribute('cuda') != -1 and torch.cuda.is_available():
+        g = g.to(get_attribute('cuda'))
+    return g
 
 def convert_all_data_to_gpu(*data):
     res = []


### PR DESCRIPTION
Dear authors,

Thanks for using DGL, recently I read [this thread](https://discuss.dgl.ai/t/is-it-possible-to-run-dgl-message-passing-computation-step-on-cpu-but-rest-of-the-deep-learning-computations-on-gpu/1496/3) in DGL discussion forum, and found your repo.

I noticed that you use user defined message and reduce functions to manipulate weighted graph conv, which is not necessary because you are basically dealing with multiplications of node and edge features with broadcasting (dgl's builtin functions support broadcasting semantics). We don't encourage users using UDF, which is costly in terms of both speed and GPU memory.

This PR rewrites the message passing with `dgl.function`s and make some changes to the codebase to make it compatible with DGL 0.5. On my machine, the refactoring reduces GPU memory usage from 5072mb to 1628 mb.

Best,
Zihao